### PR TITLE
Use multistage build so that the image is published from the runtime …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM microsoft/dotnet:2.1.504-sdk AS builder
-
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1-stretch AS builder
 ENV NBGV_VERSION 2.3.38
-
 RUN dotnet tool install --global nbgv --version $NBGV_VERSION 
 
-ENV PATH="/root/.dotnet/tools:${PATH}"
-
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1-stretch-slim
+COPY --from=builder /root/.dotnet/tools/ /opt/bin
+ENV PATH="/opt/bin:${PATH}"
 ENTRYPOINT ["nbgv"]


### PR DESCRIPTION
…image instead of the SDK image.

This brings the final image size to 230MB down from 1.8GB.
Tried using alpine but ran into libgit2 issues (maybe related to https://github.com/AArnott/Nerdbank.GitVersioning/issues/314 )